### PR TITLE
Added float to calculate percentage

### DIFF
--- a/addons/yamms/MultiScatter.gd
+++ b/addons/yamms/MultiScatter.gd
@@ -129,7 +129,7 @@ func do_generate():
 		var data = _get_scatter_items_data()
 		for entry in data:
 			# Calculate the amount of mesh items depending on the amount and proportion
-			var percentage = (100 * entry["Proportion"]) / _sum_proportion
+			var percentage : float = (float(100) * entry["Proportion"]) / _sum_proportion
 			var amount_for_proportion : int = float(amount) / 100 * percentage
 
 			# set the spawn data to the MultiMeshItem to prepare generation


### PR DESCRIPTION
When calculating the percentage of how many MultiScatterItems shall be dropped, a float is being used. This allowes percentages below 1.